### PR TITLE
fix audio recording on android

### DIFF
--- a/src/components/helpers/PlaySounds.tsx
+++ b/src/components/helpers/PlaySounds.tsx
@@ -1,4 +1,5 @@
 import { AppLoading, Audio, Permissions } from 'expo';
+import { dropLast } from 'ramda';
 import * as React from 'react';
 import { TouchableOpacityProperties } from 'react-native';
 
@@ -68,7 +69,8 @@ class PlaySoundsInner extends React.Component<
               shouldDuckAndroid: true,
               // @ts-ignore
               interruptionModeAndroid:
-                Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX
+                Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX,
+              playThroughEarpieceAndroid: false
             })
           )
           .then(() =>
@@ -109,14 +111,15 @@ class PlaySoundsInner extends React.Component<
               shouldDuckAndroid: true,
               // @ts-ignore
               interruptionModeAndroid:
-                Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX
+                Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX,
+              playThroughEarpieceAndroid: false
             })
           )
-          .then(() => recording.createNewLoadedSound())
+          .then(() => recording.createNewLoadedSoundAsync())
           .then(({ sound }: { sound: Audio.Sound }) => {
             play(sound)
               .then(() => sound.unloadAsync())
-              .then(() => playAll(sounds, delay))
+              .then(() => playAll(dropLast(1, sounds), delay))
               .then(() => {
                 onPlayEnd();
               });


### PR DESCRIPTION
* add `playThroughEarpieceAndroid` to setAudioModeAsync (add in [expo v30.0.0](https://docs.expo.io/versions/v30.0.0/sdk/audio/#playthroughearpieceandroid--set-to-true-to-route))
* `createNewLoadedSoundAsync` instead of deprecated `createNewLoadedSound`
* remove repeat sound at the end