### PR TITLE
fix: Don't play long sounds in repeat lesson

### DIFF
--- a/src/components/exercises/show-word.component.js
+++ b/src/components/exercises/show-word.component.js
@@ -83,7 +83,7 @@ export const ShowWord = ({ word, letter, sound, setState, repeat }) => {
     <PortraitScreenOrientation>
       <WordImageWithSounds
         playInitially
-        longSound
+        longSound={!repeat}
         record={repeat}
         word={word}
         onPlayEnd={() => setState(true)}


### PR DESCRIPTION
related to #359: As just discussed with @gesine57, we should only play the long sounds in Show Words exercise and not in Repeat Words exercise.